### PR TITLE
feat(ui): add resizable inventory and log windows

### DIFF
--- a/docs/specs/reference/technical-solutions/react-app-orchestration/spec.md
+++ b/docs/specs/reference/technical-solutions/react-app-orchestration/spec.md
@@ -10,7 +10,7 @@ This spec covers the top-level React hook composition and derived view-model pat
 - This reduces pressure on the top-level app component and keeps domain logic testable.
 - `useAppGameView` computes the current tile, filtered logs, town stock, recipe visibility, claim status, player stats, and other UI-ready derived values.
 - This keeps presentational components mostly declarative.
-- The game uses a desktop-style draggable window model with persisted positions and visibility.
+- The game uses a desktop-style draggable window model with persisted positions, optional per-window dimensions for resizable windows, and visibility.
 - Secondary window content is separated into dedicated components and lazy-loaded bundles following the current project pattern.
 
 ## Main Implementation Areas

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -6,6 +6,8 @@ export { WORLD_RADIUS, WORLD_REVEAL_RADIUS, HEX_SIZE };
 export interface WindowPosition {
   x: number;
   y: number;
+  width?: number;
+  height?: number;
 }
 
 export interface WindowPositions {

--- a/src/persistence/storage.test.ts
+++ b/src/persistence/storage.test.ts
@@ -9,7 +9,7 @@ describe('encrypted storage', () => {
     const payload = {
       game: { turn: 7, player: { hp: 12 } },
       ui: {
-        windows: { hero: { x: 10, y: 20 } },
+        windows: { hero: { x: 10, y: 20, width: 420, height: 280 } },
         windowShown: { hero: true },
       },
     };

--- a/src/ui/components/DraggableWindow/DraggableWindow.tsx
+++ b/src/ui/components/DraggableWindow/DraggableWindow.tsx
@@ -26,12 +26,19 @@ export function DraggableWindow({
   visible: visibleProp,
   onClose,
   showCloseButton = true,
+  resizeBounds,
 }: DraggableWindowProps) {
   const windowRef = useRef<HTMLElement | null>(null);
   const windowIdRef = useRef(`window-${Math.random().toString(36).slice(2)}`);
   const dragRef = useRef<{ dx: number; dy: number } | null>(null);
+  const resizeRef = useRef<{
+    startX: number;
+    startY: number;
+    startWidth: number;
+    startHeight: number;
+  } | null>(null);
   const frameRef = useRef<number | null>(null);
-  const pendingMoveRef = useRef<WindowPosition | null>(null);
+  const pendingLayoutRef = useRef<WindowPosition | null>(null);
   const visualPositionRef = useRef(position);
   const [visibleState, setVisibleState] = useState(true);
   const [hovered, setHovered] = useState(false);
@@ -46,13 +53,17 @@ export function DraggableWindow({
     if (!node) return;
     node.style.left = `${nextPosition.x}px`;
     node.style.top = `${nextPosition.y}px`;
+    node.style.width =
+      nextPosition.width === undefined ? '' : `${nextPosition.width}px`;
+    node.style.height =
+      nextPosition.height === undefined ? '' : `${nextPosition.height}px`;
   }, []);
 
-  const flushPendingMove = useCallback(() => {
+  const flushPendingLayout = useCallback(() => {
     frameRef.current = null;
-    const nextPosition = pendingMoveRef.current;
+    const nextPosition = pendingLayoutRef.current;
     if (!nextPosition) return;
-    pendingMoveRef.current = null;
+    pendingLayoutRef.current = null;
     onMove(nextPosition);
   }, [onMove]);
 
@@ -130,11 +141,13 @@ export function DraggableWindow({
       const nextPosition = {
         x: Math.max(8, moveEvent.clientX - dragRef.current.dx),
         y: Math.max(8, moveEvent.clientY - dragRef.current.dy),
+        width: visualPositionRef.current.width,
+        height: visualPositionRef.current.height,
       };
       applyVisualPosition(nextPosition);
-      pendingMoveRef.current = nextPosition;
+      pendingLayoutRef.current = nextPosition;
       if (frameRef.current === null) {
-        frameRef.current = window.requestAnimationFrame(flushPendingMove);
+        frameRef.current = window.requestAnimationFrame(flushPendingLayout);
       }
     };
 
@@ -142,7 +155,58 @@ export function DraggableWindow({
       dragRef.current = null;
       if (frameRef.current !== null) {
         window.cancelAnimationFrame(frameRef.current);
-        flushPendingMove();
+        flushPendingLayout();
+      }
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+    };
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+  };
+
+  const onResizePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!resizeBounds) return;
+    event.stopPropagation();
+    activateWindow();
+    const node = windowRef.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    resizeRef.current = {
+      startX: event.clientX,
+      startY: event.clientY,
+      startWidth: rect.width,
+      startHeight: rect.height,
+    };
+
+    const onPointerMove = (moveEvent: PointerEvent) => {
+      if (!resizeRef.current) return;
+      const nextPosition = {
+        x: visualPositionRef.current.x,
+        y: visualPositionRef.current.y,
+        width: Math.max(
+          resizeBounds.minWidth,
+          resizeRef.current.startWidth +
+            (moveEvent.clientX - resizeRef.current.startX),
+        ),
+        height: Math.max(
+          resizeBounds.minHeight,
+          resizeRef.current.startHeight +
+            (moveEvent.clientY - resizeRef.current.startY),
+        ),
+      };
+      applyVisualPosition(nextPosition);
+      pendingLayoutRef.current = nextPosition;
+      if (frameRef.current === null) {
+        frameRef.current = window.requestAnimationFrame(flushPendingLayout);
+      }
+    };
+
+    const onPointerUp = () => {
+      resizeRef.current = null;
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+        flushPendingLayout();
       }
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
@@ -209,6 +273,13 @@ export function DraggableWindow({
         </div>
       </div>
       <div className={styles.windowBody}>{children}</div>
+      {resizeBounds ? (
+        <div
+          className={styles.resizeHandle}
+          onPointerDown={onResizePointerDown}
+          aria-hidden="true"
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/ui/components/DraggableWindow/styles.module.scss
+++ b/src/ui/components/DraggableWindow/styles.module.scss
@@ -93,6 +93,35 @@
   padding: 0.9rem 1rem 1rem;
   display: grid;
   gap: 0.75rem;
+  flex: 1 1 auto;
   min-height: 0;
   overflow: visible;
+}
+
+.resizeHandle {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 1.2rem;
+  height: 1.2rem;
+  cursor: nwse-resize;
+  background:
+    linear-gradient(
+      135deg,
+      transparent 0,
+      transparent 45%,
+      rgb(148 163 184 / 45%) 45%,
+      rgb(148 163 184 / 45%) 55%,
+      transparent 55%,
+      transparent 100%
+    ),
+    linear-gradient(
+      135deg,
+      transparent 0,
+      transparent 62%,
+      rgb(148 163 184 / 65%) 62%,
+      rgb(148 163 184 / 65%) 72%,
+      transparent 72%,
+      transparent 100%
+    );
 }

--- a/src/ui/components/DraggableWindow/types.ts
+++ b/src/ui/components/DraggableWindow/types.ts
@@ -12,4 +12,8 @@ export interface DraggableWindowProps {
   visible?: boolean;
   onClose?: () => void;
   showCloseButton?: boolean;
+  resizeBounds?: {
+    minWidth: number;
+    minHeight: number;
+  };
 }

--- a/src/ui/components/InventoryWindow/InventoryWindow.tsx
+++ b/src/ui/components/InventoryWindow/InventoryWindow.tsx
@@ -39,6 +39,7 @@ export const InventoryWindow = memo(function InventoryWindow({
       className={styles.window}
       visible={visible}
       onClose={onClose}
+      resizeBounds={{ minWidth: 320, minHeight: 220 }}
       headerActions={
         <div className={styles.toolbar}>
           <div className={styles.actions}>

--- a/src/ui/components/InventoryWindow/styles.module.scss
+++ b/src/ui/components/InventoryWindow/styles.module.scss
@@ -2,6 +2,9 @@
 
 .window {
   width: min(410px, calc(100vw - 16px));
+  height: min(360px, calc(100vh - 16px));
+  display: flex;
+  flex-direction: column;
   overflow: visible;
 
   @media (width <= 980px) {
@@ -27,7 +30,8 @@
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
-  max-height: min(48vh, 480px);
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: visible auto;
   scrollbar-gutter: stable;
   padding-bottom: 5px;

--- a/src/ui/components/LogWindow/LogWindow.tsx
+++ b/src/ui/components/LogWindow/LogWindow.tsx
@@ -41,6 +41,7 @@ export const LogWindow = memo(function LogWindow({
       titleClassName={styles.windowTitle}
       visible={visible}
       onClose={onClose}
+      resizeBounds={{ minWidth: 360, minHeight: 240 }}
       headerActions={
         <div className={styles.toolbar}>
           <button className={styles.headerButton} onClick={onToggleMenu}>

--- a/src/ui/components/LogWindow/styles.module.scss
+++ b/src/ui/components/LogWindow/styles.module.scss
@@ -2,6 +2,9 @@
 
 .window {
   width: min(520px, calc(100vw - 16px));
+  height: min(360px, calc(100vh - 16px));
+  display: flex;
+  flex-direction: column;
 
   button:hover {
     background: rgb(8 22 12 / 96%);
@@ -82,9 +85,8 @@
 }
 
 .logList {
-  display: grid;
-  gap: 0.05rem;
-  max-height: min(42vh, 420px);
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
   padding: 0;
 }

--- a/src/ui/ui.test.tsx
+++ b/src/ui/ui.test.tsx
@@ -1032,6 +1032,84 @@ describe('ui helpers and components', () => {
     host.remove();
   });
 
+  it('resizes draggable windows through the shared resize handle', async () => {
+    const moves: Array<{
+      x: number;
+      y: number;
+      width?: number;
+      height?: number;
+    }> = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    let root: Root | null = createRoot(host);
+
+    await act(async () => {
+      root?.render(
+        <DraggableWindow
+          title="Resizable Window"
+          position={{ x: 40, y: 50, width: 320, height: 240 }}
+          onMove={(position) => moves.push(position)}
+          resizeBounds={{ minWidth: 280, minHeight: 200 }}
+        >
+          <div>Body</div>
+        </DraggableWindow>,
+      );
+    });
+
+    const windowElement = host.querySelector(
+      'section[class*="floatingWindow"]',
+    ) as HTMLElement | null;
+    const resizeHandle = host.querySelector(
+      'div[class*="resizeHandle"]',
+    ) as HTMLDivElement | null;
+
+    expect(windowElement).not.toBeNull();
+    expect(resizeHandle).not.toBeNull();
+
+    vi.spyOn(windowElement!, 'getBoundingClientRect').mockReturnValue({
+      x: 40,
+      y: 50,
+      top: 50,
+      left: 40,
+      bottom: 290,
+      right: 360,
+      width: 320,
+      height: 240,
+      toJSON: () => ({}),
+    });
+
+    await act(async () => {
+      resizeHandle?.dispatchEvent(
+        new MouseEvent('pointerdown', {
+          bubbles: true,
+          clientX: 360,
+          clientY: 290,
+        }),
+      );
+      window.dispatchEvent(
+        new MouseEvent('pointermove', {
+          bubbles: true,
+          clientX: 420,
+          clientY: 340,
+        }),
+      );
+      window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    });
+
+    expect(moves[moves.length - 1]).toEqual({
+      x: 40,
+      y: 50,
+      width: 380,
+      height: 290,
+    });
+
+    await act(async () => {
+      root?.unmount();
+    });
+    root = null;
+    host.remove();
+  });
+
   it('scrolls the log window to the newest message', async () => {
     vi.useFakeTimers();
     const game = createGame(2, 'log-scroll-test');


### PR DESCRIPTION
Extend the shared draggable window layout to persist optional dimensions.
Add resize support for the inventory and log windows.
Cover the new behavior with UI and persistence tests.