### PR TITLE
fix(ui): keep window shells mounted during content retries

### DIFF
--- a/docs/specs/reference/technical-solutions/react-app-orchestration/spec.md
+++ b/docs/specs/reference/technical-solutions/react-app-orchestration/spec.md
@@ -12,6 +12,8 @@ This spec covers the top-level React hook composition and derived view-model pat
 - This keeps presentational components mostly declarative.
 - The game uses a desktop-style draggable window model with persisted positions and visibility.
 - Secondary window content is separated into dedicated components and lazy-loaded bundles following the current project pattern.
+- Deferred window-content imports retry indefinitely when a bundle fails to load, keeping the rest of the game interactive while the affected window shell stays mounted on its loading fallback.
+- Window loading fallbacks keep the spinner visible and add delayed explanatory copy when the deferred content is still unavailable after several seconds.
 
 ## Main Implementation Areas
 

--- a/src/app/App/AppWindows.tsx
+++ b/src/app/App/AppWindows.tsx
@@ -1,11 +1,4 @@
-import {
-  lazy,
-  Suspense,
-  useEffect,
-  useMemo,
-  useState,
-  type MutableRefObject,
-} from 'react';
+import { useEffect, useMemo, useState, type MutableRefObject } from 'react';
 import {
   canEquipItem,
   canUseItem,
@@ -25,67 +18,21 @@ import {
 } from '../constants';
 import { GameTooltip } from '../../ui/components/GameTooltip';
 import { HeroWindow } from '../../ui/components/HeroWindow';
-import { WindowLoadingState } from '../../ui/components/WindowLoadingState';
+import { SkillsWindow } from '../../ui/components/SkillsWindow';
+import { HexInfoWindow } from '../../ui/components/HexInfoWindow';
+import { EquipmentWindow } from '../../ui/components/EquipmentWindow';
+import { InventoryWindow } from '../../ui/components/InventoryWindow';
+import { RecipeBookWindow } from '../../ui/components/RecipeBookWindow';
+import { LogWindow } from '../../ui/components/LogWindow';
+import { CombatWindow } from '../../ui/components/CombatWindow';
+import { LootWindow } from '../../ui/components/LootWindow';
+import { ItemContextMenu } from '../../ui/components/ItemContextMenu';
 import { WindowDock } from '../../ui/components/WindowDock';
 import type { ItemContextMenuState, TooltipItem } from './types';
 import type { TooltipPosition } from '../../ui/components/GameTooltip';
 import type { TooltipLine } from '../../ui/tooltips';
 import { formatTerrainLabel } from './appHelpers';
 import { useTooltipState } from './tooltipStore';
-
-const SkillsWindow = lazy(() =>
-  import('../../ui/components/SkillsWindow').then((module) => ({
-    default: module.SkillsWindow,
-  })),
-);
-
-const HexInfoWindow = lazy(() =>
-  import('../../ui/components/HexInfoWindow').then((module) => ({
-    default: module.HexInfoWindow,
-  })),
-);
-
-const EquipmentWindow = lazy(() =>
-  import('../../ui/components/EquipmentWindow').then((module) => ({
-    default: module.EquipmentWindow,
-  })),
-);
-
-const InventoryWindow = lazy(() =>
-  import('../../ui/components/InventoryWindow').then((module) => ({
-    default: module.InventoryWindow,
-  })),
-);
-
-const RecipeBookWindow = lazy(() =>
-  import('../../ui/components/RecipeBookWindow').then((module) => ({
-    default: module.RecipeBookWindow,
-  })),
-);
-
-const LogWindow = lazy(() =>
-  import('../../ui/components/LogWindow').then((module) => ({
-    default: module.LogWindow,
-  })),
-);
-
-const CombatWindow = lazy(() =>
-  import('../../ui/components/CombatWindow').then((module) => ({
-    default: module.CombatWindow,
-  })),
-);
-
-const LootWindow = lazy(() =>
-  import('../../ui/components/LootWindow').then((module) => ({
-    default: module.LootWindow,
-  })),
-);
-
-const ItemContextMenu = lazy(() =>
-  import('../../ui/components/ItemContextMenu').then((module) => ({
-    default: module.ItemContextMenu,
-  })),
-);
 
 interface AppWindowsProps {
   windows: WindowPositions;
@@ -322,208 +269,190 @@ export function AppWindows({
         onLeaveDetail={onCloseTooltip}
       />
       {loadedWindows.skills ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <SkillsWindow
-            position={windows.skills}
-            onMove={windowMoveHandlers.skills}
-            visible={windowShown.skills}
-            onClose={windowCloseHandlers.skills}
-            skills={stats.skills}
-            onHoverDetail={onShowTooltip}
-            onLeaveDetail={onCloseTooltip}
-          />
-        </Suspense>
+        <SkillsWindow
+          position={windows.skills}
+          onMove={windowMoveHandlers.skills}
+          visible={windowShown.skills}
+          onClose={windowCloseHandlers.skills}
+          skills={stats.skills}
+          onHoverDetail={onShowTooltip}
+          onLeaveDetail={onCloseTooltip}
+        />
       ) : null}
       {loadedWindows.recipes ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <RecipeBookWindow
-            position={windows.recipes}
-            onMove={windowMoveHandlers.recipes}
-            visible={windowShown.recipes}
-            onClose={windowCloseHandlers.recipes}
-            hasRecipeBook={recipeBookKnown}
-            currentStructure={describeStructure(currentTile.structure)}
-            recipes={recipes}
-            inventoryCounts={inventoryCounts}
-            onCraft={onCraftRecipe}
-          />
-        </Suspense>
+        <RecipeBookWindow
+          position={windows.recipes}
+          onMove={windowMoveHandlers.recipes}
+          visible={windowShown.recipes}
+          onClose={windowCloseHandlers.recipes}
+          hasRecipeBook={recipeBookKnown}
+          currentStructure={describeStructure(currentTile.structure)}
+          recipes={recipes}
+          inventoryCounts={inventoryCounts}
+          onCraft={onCraftRecipe}
+        />
       ) : null}
       {loadedWindows.hexInfo ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <HexInfoWindow
-            position={windows.hexInfo}
-            onMove={windowMoveHandlers.hexInfo}
-            visible={windowShown.hexInfo}
-            onClose={windowCloseHandlers.hexInfo}
-            isHome={
-              game.homeHex.q === game.player.coord.q &&
-              game.homeHex.r === game.player.coord.r
-            }
-            canSetHome={
-              !currentTile.claim || currentTile.claim.ownerType === 'player'
-            }
-            onSetHome={onSetHome}
-            terrain={formatTerrainLabel(currentTile.terrain)}
-            structure={
-              currentTile.structure
-                ? describeStructure(currentTile.structure)
-                : null
-            }
-            enemyCount={
-              game.combat
-                ? (combatSnapshot?.enemies.length ?? 0)
-                : getHostileEnemyIds(game, currentTile.coord).length
-            }
-            interactLabel={interactLabel}
-            canInteract={Boolean(interactLabel)}
-            canProspect={canProspect}
-            canSell={canSell}
-            canClaim={claimStatus.canClaim}
-            claimExplanation={claimStatus.reason}
-            prospectExplanation={prospectExplanation}
-            sellExplanation={sellExplanation}
-            onInteract={onInteract}
-            onProspect={onProspect}
-            onSellAll={onSellAll}
-            onClaim={onClaimHex}
-            structureHp={currentTile.structureHp}
-            structureMaxHp={currentTile.structureMaxHp}
-            territoryName={currentTile.claim?.ownerName ?? null}
-            territoryOwnerType={currentTile.claim?.ownerType ?? null}
-            territoryNpc={currentTile.claim?.npc ?? null}
-            townStock={townStock}
-            gold={gold}
-            onBuyItem={onBuyTownItem}
-            onHoverItem={onShowItemTooltip}
-            onLeaveItem={onCloseTooltip}
-          />
-        </Suspense>
+        <HexInfoWindow
+          position={windows.hexInfo}
+          onMove={windowMoveHandlers.hexInfo}
+          visible={windowShown.hexInfo}
+          onClose={windowCloseHandlers.hexInfo}
+          isHome={
+            game.homeHex.q === game.player.coord.q &&
+            game.homeHex.r === game.player.coord.r
+          }
+          canSetHome={
+            !currentTile.claim || currentTile.claim.ownerType === 'player'
+          }
+          onSetHome={onSetHome}
+          terrain={formatTerrainLabel(currentTile.terrain)}
+          structure={
+            currentTile.structure
+              ? describeStructure(currentTile.structure)
+              : null
+          }
+          enemyCount={
+            game.combat
+              ? (combatSnapshot?.enemies.length ?? 0)
+              : getHostileEnemyIds(game, currentTile.coord).length
+          }
+          interactLabel={interactLabel}
+          canInteract={Boolean(interactLabel)}
+          canProspect={canProspect}
+          canSell={canSell}
+          canClaim={claimStatus.canClaim}
+          claimExplanation={claimStatus.reason}
+          prospectExplanation={prospectExplanation}
+          sellExplanation={sellExplanation}
+          onInteract={onInteract}
+          onProspect={onProspect}
+          onSellAll={onSellAll}
+          onClaim={onClaimHex}
+          structureHp={currentTile.structureHp}
+          structureMaxHp={currentTile.structureMaxHp}
+          territoryName={currentTile.claim?.ownerName ?? null}
+          territoryOwnerType={currentTile.claim?.ownerType ?? null}
+          territoryNpc={currentTile.claim?.npc ?? null}
+          townStock={townStock}
+          gold={gold}
+          onBuyItem={onBuyTownItem}
+          onHoverItem={onShowItemTooltip}
+          onLeaveItem={onCloseTooltip}
+        />
       ) : null}
       {loadedWindows.equipment ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <EquipmentWindow
-            position={windows.equipment}
-            onMove={windowMoveHandlers.equipment}
-            visible={windowShown.equipment}
-            onClose={windowCloseHandlers.equipment}
-            equipment={game.player.equipment}
-            onHoverItem={onEquipmentHover}
-            onLeaveItem={onCloseTooltip}
-            onUnequip={onUnequip}
-            onContextItem={onEquippedContextItem}
-          />
-        </Suspense>
+        <EquipmentWindow
+          position={windows.equipment}
+          onMove={windowMoveHandlers.equipment}
+          visible={windowShown.equipment}
+          onClose={windowCloseHandlers.equipment}
+          equipment={game.player.equipment}
+          onHoverItem={onEquipmentHover}
+          onLeaveItem={onCloseTooltip}
+          onUnequip={onUnequip}
+          onContextItem={onEquippedContextItem}
+        />
       ) : null}
       {loadedWindows.inventory ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <InventoryWindow
-            position={windows.inventory}
-            onMove={windowMoveHandlers.inventory}
-            visible={windowShown.inventory}
-            onClose={windowCloseHandlers.inventory}
-            inventory={game.player.inventory}
-            equipment={game.player.equipment}
-            onSort={onSort}
-            onEquip={onEquip}
-            onContextItem={onContextItem}
-            onHoverItem={onShowItemTooltip}
-            onLeaveItem={onCloseTooltip}
-          />
-        </Suspense>
+        <InventoryWindow
+          position={windows.inventory}
+          onMove={windowMoveHandlers.inventory}
+          visible={windowShown.inventory}
+          onClose={windowCloseHandlers.inventory}
+          inventory={game.player.inventory}
+          equipment={game.player.equipment}
+          onSort={onSort}
+          onEquip={onEquip}
+          onContextItem={onContextItem}
+          onHoverItem={onShowItemTooltip}
+          onLeaveItem={onCloseTooltip}
+        />
       ) : null}
       {loadedWindows.loot ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <LootWindow
-            position={windows.loot}
-            onMove={windowMoveHandlers.loot}
-            visible={windowShown.loot && lootWindowVisible}
-            loot={lootSnapshot}
-            equipment={game.player.equipment}
-            onClose={windowCloseHandlers.loot}
-            onTakeAll={onTakeAllLoot}
-            onTakeItem={onTakeLootItem}
-            onHoverItem={onShowItemTooltip}
-            onLeaveItem={onCloseTooltip}
-          />
-        </Suspense>
+        <LootWindow
+          position={windows.loot}
+          onMove={windowMoveHandlers.loot}
+          visible={windowShown.loot && lootWindowVisible}
+          loot={lootSnapshot}
+          equipment={game.player.equipment}
+          onClose={windowCloseHandlers.loot}
+          onTakeAll={onTakeAllLoot}
+          onTakeItem={onTakeLootItem}
+          onHoverItem={onShowItemTooltip}
+          onLeaveItem={onCloseTooltip}
+        />
       ) : null}
       {itemMenu ? (
-        <Suspense fallback={null}>
-          <ItemContextMenu
-            item={itemMenu.item}
-            x={itemMenu.x}
-            y={itemMenu.y}
-            equipLabel={itemMenu.slot ? 'Unequip' : 'Equip'}
-            canEquip={itemMenu.slot ? true : canEquipItem(itemMenu.item)}
-            canUse={canUseItem(itemMenu.item)}
-            onEquip={() => {
-              if (itemMenu.slot) {
-                onUnequip(itemMenu.slot);
-              } else {
-                onEquip(itemMenu.item.id);
-              }
-              onCloseItemMenu();
-            }}
-            onUse={() => {
-              onUseItem(itemMenu.item.id);
-              onCloseItemMenu();
-            }}
-            onDrop={() => {
-              if (itemMenu.slot) {
-                onDropEquippedItem(itemMenu.slot);
-              } else {
-                onDropItem(itemMenu.item.id);
-              }
-              onCloseItemMenu();
-            }}
-            onClose={onCloseItemMenu}
-          />
-        </Suspense>
+        <ItemContextMenu
+          item={itemMenu.item}
+          x={itemMenu.x}
+          y={itemMenu.y}
+          equipLabel={itemMenu.slot ? 'Unequip' : 'Equip'}
+          canEquip={itemMenu.slot ? true : canEquipItem(itemMenu.item)}
+          canUse={canUseItem(itemMenu.item)}
+          onEquip={() => {
+            if (itemMenu.slot) {
+              onUnequip(itemMenu.slot);
+            } else {
+              onEquip(itemMenu.item.id);
+            }
+            onCloseItemMenu();
+          }}
+          onUse={() => {
+            onUseItem(itemMenu.item.id);
+            onCloseItemMenu();
+          }}
+          onDrop={() => {
+            if (itemMenu.slot) {
+              onDropEquippedItem(itemMenu.slot);
+            } else {
+              onDropItem(itemMenu.item.id);
+            }
+            onCloseItemMenu();
+          }}
+          onClose={onCloseItemMenu}
+        />
       ) : null}
       {loadedWindows.log ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <LogWindow
-            position={windows.log}
-            onMove={windowMoveHandlers.log}
-            visible={windowShown.log}
-            onClose={windowCloseHandlers.log}
-            filters={logFilters}
-            defaultFilters={DEFAULT_LOG_FILTERS}
-            showFilterMenu={showFilterMenu}
-            onToggleMenu={onToggleFilterMenu}
-            onToggleFilter={onToggleLogFilter}
-            logs={filteredLogs}
-          />
-        </Suspense>
+        <LogWindow
+          position={windows.log}
+          onMove={windowMoveHandlers.log}
+          visible={windowShown.log}
+          onClose={windowCloseHandlers.log}
+          filters={logFilters}
+          defaultFilters={DEFAULT_LOG_FILTERS}
+          showFilterMenu={showFilterMenu}
+          onToggleMenu={onToggleFilterMenu}
+          onToggleFilter={onToggleLogFilter}
+          logs={filteredLogs}
+        />
       ) : null}
       {loadedWindows.combat && combatSnapshot ? (
-        <Suspense fallback={<WindowLoadingState />}>
-          <CombatWindow
-            position={windows.combat}
-            onMove={windowMoveHandlers.combat}
-            visible={windowShown.combat && combatWindowVisible}
-            onClose={windowCloseHandlers.combat}
-            combat={combatSnapshot.combat}
-            playerParty={[
-              {
-                id: 'player',
-                name: 'Player',
-                level: stats.level,
-                hp: stats.hp,
-                maxHp: stats.maxHp,
-                mana: game.player.mana,
-                maxMana: stats.maxMana,
-                actor: combatSnapshot.combat.player,
-              },
-            ]}
-            enemies={combatSnapshot.enemies}
-            worldTimeMs={game.worldTimeMs}
-            onStart={onStartCombat}
-            onHoverDetail={onShowTooltip}
-            onLeaveDetail={onCloseTooltip}
-          />
-        </Suspense>
+        <CombatWindow
+          position={windows.combat}
+          onMove={windowMoveHandlers.combat}
+          visible={windowShown.combat && combatWindowVisible}
+          onClose={windowCloseHandlers.combat}
+          combat={combatSnapshot.combat}
+          playerParty={[
+            {
+              id: 'player',
+              name: 'Player',
+              level: stats.level,
+              hp: stats.hp,
+              maxHp: stats.maxHp,
+              mana: game.player.mana,
+              maxMana: stats.maxMana,
+              actor: combatSnapshot.combat.player,
+            },
+          ]}
+          enemies={combatSnapshot.enemies}
+          worldTimeMs={game.worldTimeMs}
+          onStart={onStartCombat}
+          onHoverDetail={onShowTooltip}
+          onLeaveDetail={onCloseTooltip}
+        />
       ) : null}
       <GameTooltip tooltip={tooltip} positionRef={tooltipPositionRef} />
     </>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -294,6 +294,7 @@
   "ui.loot.takeAllAction": "Tak(e) all",
   "ui.loot.title": "Loot on the Ground",
   "ui.loading.window": "Loading window",
+  "ui.loading.windowDelayed": "This window is taking longer to load than expected. Trying again…",
   "ui.log.filtersAction": "Filters",
   "ui.log.kind.combat.label": "combat",
   "ui.log.kind.loot.label": "loot",

--- a/src/ui/components/CombatWindow/CombatWindow.tsx
+++ b/src/ui/components/CombatWindow/CombatWindow.tsx
@@ -2,14 +2,17 @@ import { lazy, Suspense } from 'react';
 import { t } from '../../../i18n';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import inventoryStyles from '../InventoryWindow/styles.module.scss';
 import type { CombatWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const CombatWindowContent = lazy(() =>
-  import('./CombatWindowContent').then((module) => ({
-    default: module.CombatWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./CombatWindowContent').then((module) => ({
+      default: module.CombatWindowContent,
+    })),
+  ),
 );
 
 export function CombatWindow({

--- a/src/ui/components/DebuggerWindow/DebuggerWindow.tsx
+++ b/src/ui/components/DebuggerWindow/DebuggerWindow.tsx
@@ -3,14 +3,17 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import labelStyles from '../windowLabels.module.scss';
 import type { DebuggerWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const DebuggerWindowContent = lazy(() =>
-  import('./DebuggerWindowContent').then((module) => ({
-    default: module.DebuggerWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./DebuggerWindowContent').then((module) => ({
+      default: module.DebuggerWindowContent,
+    })),
+  ),
 );
 
 export const DebuggerWindow = memo(function DebuggerWindow({

--- a/src/ui/components/HeroWindow/HeroWindow.test.tsx
+++ b/src/ui/components/HeroWindow/HeroWindow.test.tsx
@@ -1,0 +1,76 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { t } from '../../../i18n';
+import { HeroWindow } from './HeroWindow';
+import type { HeroWindowStats } from './types';
+
+const stats: HeroWindowStats = {
+  hp: 10,
+  maxHp: 10,
+  mana: 5,
+  maxMana: 5,
+  xp: 0,
+  nextLevelXp: 10,
+  rawAttack: 1,
+  rawDefense: 1,
+  attack: 1,
+  defense: 1,
+  buffs: [],
+  debuffs: [],
+  abilityIds: [],
+  level: 1,
+  masteryLevel: 0,
+  skills: {
+    cooking: { level: 1, xp: 0 },
+    crafting: { level: 1, xp: 0 },
+    fishing: { level: 1, xp: 0 },
+    logging: { level: 1, xp: 0 },
+    mining: { level: 1, xp: 0 },
+    skinning: { level: 1, xp: 0 },
+  },
+};
+
+describe('HeroWindow', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+
+  it('renders the window shell while content is still loading', async () => {
+    await act(async () => {
+      root.render(
+        <HeroWindow
+          position={{ x: 16, y: 24 }}
+          onMove={() => {}}
+          visible
+          stats={stats}
+          hunger={0}
+          thirst={0}
+          worldTimeMs={0}
+        />,
+      );
+    });
+
+    expect(host.textContent).toContain(t('ui.window.hero.suffix'));
+    expect(
+      host.querySelector(`[aria-label="${t('ui.loading.window')}"]`),
+    ).not.toBeNull();
+  });
+});

--- a/src/ui/components/HeroWindow/HeroWindow.tsx
+++ b/src/ui/components/HeroWindow/HeroWindow.tsx
@@ -3,13 +3,16 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import labelStyles from '../windowLabels.module.scss';
 import type { HeroWindowProps } from './types';
 
 const HeroWindowContent = lazy(() =>
-  import('./HeroWindowContent').then((module) => ({
-    default: module.HeroWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./HeroWindowContent').then((module) => ({
+      default: module.HeroWindowContent,
+    })),
+  ),
 );
 
 export const HeroWindow = memo(function HeroWindow({

--- a/src/ui/components/HexInfoWindow/HexInfoWindow.tsx
+++ b/src/ui/components/HexInfoWindow/HexInfoWindow.tsx
@@ -4,15 +4,18 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import inventoryStyles from '../InventoryWindow/styles.module.scss';
 import labelStyles from '../windowLabels.module.scss';
 import type { HexInfoWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const HexInfoWindowContent = lazy(() =>
-  import('./HexInfoWindowContent').then((module) => ({
-    default: module.HexInfoWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./HexInfoWindowContent').then((module) => ({
+      default: module.HexInfoWindowContent,
+    })),
+  ),
 );
 
 export const HexInfoWindow = memo(function HexInfoWindow({

--- a/src/ui/components/InventoryWindow/InventoryWindow.tsx
+++ b/src/ui/components/InventoryWindow/InventoryWindow.tsx
@@ -3,14 +3,17 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import labelStyles from '../windowLabels.module.scss';
 import type { InventoryWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const InventoryWindowContent = lazy(() =>
-  import('./InventoryWindowContent').then((module) => ({
-    default: module.InventoryWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./InventoryWindowContent').then((module) => ({
+      default: module.InventoryWindowContent,
+    })),
+  ),
 );
 
 export const InventoryWindow = memo(function InventoryWindow({

--- a/src/ui/components/LogWindow/LogWindow.tsx
+++ b/src/ui/components/LogWindow/LogWindow.tsx
@@ -5,14 +5,17 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import labelStyles from '../windowLabels.module.scss';
 import type { LogWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const LogWindowContent = lazy(() =>
-  import('./LogWindowContent').then((module) => ({
-    default: module.LogWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./LogWindowContent').then((module) => ({
+      default: module.LogWindowContent,
+    })),
+  ),
 );
 
 export const LogWindow = memo(function LogWindow({

--- a/src/ui/components/LootWindow/LootWindow.tsx
+++ b/src/ui/components/LootWindow/LootWindow.tsx
@@ -2,13 +2,16 @@ import { lazy, memo, Suspense } from 'react';
 import { t } from '../../../i18n';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import type { LootWindowProps } from './types';
 import styles from '../InventoryWindow/styles.module.scss';
 
 const LootWindowContent = lazy(() =>
-  import('./LootWindowContent').then((module) => ({
-    default: module.LootWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./LootWindowContent').then((module) => ({
+      default: module.LootWindowContent,
+    })),
+  ),
 );
 
 export const LootWindow = memo(function LootWindow({

--- a/src/ui/components/RecipeBookWindow/RecipeBookWindow.tsx
+++ b/src/ui/components/RecipeBookWindow/RecipeBookWindow.tsx
@@ -3,14 +3,17 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import labelStyles from '../windowLabels.module.scss';
 import type { RecipeBookWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const RecipeBookWindowContent = lazy(() =>
-  import('./RecipeBookWindowContent').then((module) => ({
-    default: module.RecipeBookWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./RecipeBookWindowContent').then((module) => ({
+      default: module.RecipeBookWindowContent,
+    })),
+  ),
 );
 
 export const RecipeBookWindow = memo(function RecipeBookWindow({

--- a/src/ui/components/SkillsWindow/SkillsWindow.tsx
+++ b/src/ui/components/SkillsWindow/SkillsWindow.tsx
@@ -3,14 +3,17 @@ import { WINDOW_LABELS } from '../../windowLabels';
 import { DraggableWindow } from '../DraggableWindow';
 import { WindowLabel } from '../WindowLabel/WindowLabel';
 import { WindowLoadingState } from '../WindowLoadingState';
+import { loadRetryingWindowModule } from '../lazyWindowComponent';
 import labelStyles from '../windowLabels.module.scss';
 import type { SkillsWindowProps } from './types';
 import styles from './styles.module.scss';
 
 const SkillsWindowContent = lazy(() =>
-  import('./SkillsWindowContent').then((module) => ({
-    default: module.SkillsWindowContent,
-  })),
+  loadRetryingWindowModule(() =>
+    import('./SkillsWindowContent').then((module) => ({
+      default: module.SkillsWindowContent,
+    })),
+  ),
 );
 
 export const SkillsWindow = memo(function SkillsWindow({

--- a/src/ui/components/WindowLoadingState.module.scss
+++ b/src/ui/components/WindowLoadingState.module.scss
@@ -1,9 +1,11 @@
 .loadingState {
   display: grid;
   place-items: center;
+  gap: 0.75rem;
   min-width: 260px;
   min-height: 180px;
   color: #cbd5e1;
+  text-align: center;
 }
 
 .spinner {
@@ -13,6 +15,13 @@
   border-top-color: #38bdf8;
   border-radius: 999px;
   animation: spin 0.8s linear infinite;
+}
+
+.message {
+  margin: 0;
+  max-width: 18rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
 }
 
 @keyframes spin {

--- a/src/ui/components/WindowLoadingState.test.tsx
+++ b/src/ui/components/WindowLoadingState.test.tsx
@@ -1,0 +1,51 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { t } from '../../i18n';
+import {
+  WindowLoadingState,
+  WINDOW_LOADING_WARNING_DELAY_MS,
+} from './WindowLoadingState';
+
+describe('WindowLoadingState', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+    vi.useRealTimers();
+  });
+
+  it('shows a delayed warning when window content is still loading', async () => {
+    await act(async () => {
+      root.render(<WindowLoadingState />);
+    });
+
+    expect(host.textContent).not.toContain(t('ui.loading.windowDelayed'));
+
+    await act(async () => {
+      vi.advanceTimersByTime(WINDOW_LOADING_WARNING_DELAY_MS - 1);
+    });
+    expect(host.textContent).not.toContain(t('ui.loading.windowDelayed'));
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(host.textContent).toContain(t('ui.loading.windowDelayed'));
+  });
+});

--- a/src/ui/components/WindowLoadingState.tsx
+++ b/src/ui/components/WindowLoadingState.tsx
@@ -1,7 +1,20 @@
-import styles from './WindowLoadingState.module.scss';
+import { useEffect, useState } from 'react';
 import { t } from '../../i18n';
+import styles from './WindowLoadingState.module.scss';
+
+export const WINDOW_LOADING_WARNING_DELAY_MS = 3000;
 
 export function WindowLoadingState() {
+  const [showWarning, setShowWarning] = useState(false);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setShowWarning(true);
+    }, WINDOW_LOADING_WARNING_DELAY_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, []);
+
   return (
     <div
       className={styles.loadingState}
@@ -10,6 +23,9 @@ export function WindowLoadingState() {
       aria-label={t('ui.loading.window')}
     >
       <div className={styles.spinner} aria-hidden="true" />
+      {showWarning ? (
+        <p className={styles.message}>{t('ui.loading.windowDelayed')}</p>
+      ) : null}
     </div>
   );
 }

--- a/src/ui/components/lazyWindowComponent.test.ts
+++ b/src/ui/components/lazyWindowComponent.test.ts
@@ -1,0 +1,35 @@
+import type { ComponentType } from 'react';
+import { loadRetryingWindowModule } from './lazyWindowComponent';
+
+describe('loadRetryingWindowModule', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps retrying until the window module loads', async () => {
+    const module = {
+      default: (() => null) as ComponentType,
+    };
+    const loader = vi
+      .fn<() => Promise<typeof module>>()
+      .mockRejectedValueOnce(new Error('chunk missing'))
+      .mockRejectedValueOnce(new Error('still missing'))
+      .mockResolvedValue(module);
+
+    const promise = loadRetryingWindowModule(loader, 25);
+
+    await Promise.resolve();
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(loader).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(promise).resolves.toBe(module);
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/ui/components/lazyWindowComponent.ts
+++ b/src/ui/components/lazyWindowComponent.ts
@@ -1,0 +1,20 @@
+export const WINDOW_IMPORT_RETRY_DELAY_MS = 1000;
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    globalThis.setTimeout(resolve, ms);
+  });
+}
+
+export async function loadRetryingWindowModule<T>(
+  loader: () => Promise<T>,
+  retryDelayMs = WINDOW_IMPORT_RETRY_DELAY_MS,
+): Promise<T> {
+  for (;;) {
+    try {
+      return await loader();
+    } catch {
+      await wait(retryDelayMs);
+    }
+  }
+}


### PR DESCRIPTION
Render window shells eagerly so failed lazy content loads do not break the game.
Keep the window frame visible while deferred content retries indefinitely.
Show delayed loading guidance inside the spinner fallback.